### PR TITLE
fixed issue #12 

### DIFF
--- a/internal/controllers/repository/repository.go
+++ b/internal/controllers/repository/repository.go
@@ -119,6 +119,9 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (reconciler
 
 	if repo == nil {
 		var err error
+		if len(prj.Status.Id) == 0 {
+			return reconciler.ExternalObservation{}, errors.New("TeamProject is not initialized")
+		}
 		repo, err = repositories.Find(ctx, e.azCli, repositories.FindOptions{
 			Organization: prj.Spec.Organization,
 			Project:      prj.Status.Id,


### PR DESCRIPTION
If the TeamProject resource is not initialized before making the [repositories.Find](https://github.com/krateoplatformops/azuredevops-provider/blob/e183b457a2e3cb4cdc590a2d17e0e5b8704ffbc9/internal/controllers/repository/repository.go#L122) request, the function will make an HTTP GET request without specifying the "id" in the URL. This will cause the Azure API to return a payload containing all the repositories in the organization. The find function will then search in the payload for a match with the name of the newly created repository and may find a false positive if another repository with the same name exists in another TeamProject.

**Solution**
The length of the "Id" field in the TeamProject resource is checked to be initialized before making the call to repositories.Find(). [Line 122](https://github.com/krateoplatformops/azuredevops-provider/blob/51a409f7e42cb3cf81682afbde2d3f4a0978f2e9/internal/controllers/repository/repository.go#L122)
This step ensures that the TeamProject exists and is initialized before searching for repositories with the same name
