### PR TITLE
Bug Fix - Impossible to share Service Connection with same name

### DIFF
--- a/internal/controllers/endpoints/support.go
+++ b/internal/controllers/endpoints/support.go
@@ -180,7 +180,7 @@ func addEventually(dict map[string]string, key string, val *string) {
 
 func containsRef(a []endpoints.ServiceEndpointProjectReference, b endpoints.ServiceEndpointProjectReference) bool {
 	for _, el := range a {
-		if helpers.String(el.Name) == helpers.String(b.Name) {
+		if helpers.String(el.Name) == helpers.String(b.Name) && el.ProjectReference.Name == b.ProjectReference.Name && helpers.String(el.ProjectReference.Id) == helpers.String(b.ProjectReference.Id) {
 			return true
 		}
 	}


### PR DESCRIPTION
**Describe the problem**
Impossible to share a service connection with the same name of another (contained in a different project) #20 

**Bug Fix Notes**
Fix bug that prevent the creation of a service connection with the same name of another.