### PR TITLE
fixed #47. Infinite Loop in Endpoint CR

### DIFF
--- a/internal/clients/azuredevops/endpoints/utils.go
+++ b/internal/clients/azuredevops/endpoints/utils.go
@@ -1,0 +1,48 @@
+package endpoints
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/krateoplatformops/provider-runtime/pkg/helpers"
+)
+
+func Equal(a *ServiceEndpoint, b *ServiceEndpoint) bool {
+	if helpers.String(a.Id) != helpers.String(b.Id) {
+		return false
+	}
+
+	if helpers.String(a.Url) != helpers.String(b.Url) {
+		return false
+	}
+	if helpers.String(a.Description) != helpers.String(b.Description) {
+		return false
+	}
+
+	if helpers.String(a.Type) != helpers.String(b.Type) {
+		return false
+	}
+
+	if !strings.EqualFold(helpers.String(a.Owner), helpers.String(b.Owner)) {
+		return false
+	}
+
+	if !reflect.DeepEqual(a.Data, b.Data) {
+		return false
+	}
+
+	for _, ref := range a.ServiceEndpointProjectReferences {
+		found := false
+		for _, refb := range b.ServiceEndpointProjectReferences {
+			if reflect.DeepEqual(ref, refb) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
**Related to #47**
> When creating a new CR of type 'Endpoint', the resource is correctly created on Azure Devops, but the provider will try to reconcile the CR in an infinite loop, causing lot of unwanted api calls to Azure Devops


**Fix Notes**
The Endpoint resource was not correctly compared during observation due to the non-standard response of Azure DevOps APIs. An ad-hoc function has been written to compare the state of the CR with the remote resource.