### PR TITLE
Issue #53 - CheckConfiguration with pending annotation 

### DIFF
--- a/internal/controllers/checkconfigurations/checkconfigurations.go
+++ b/internal/controllers/checkconfigurations/checkconfigurations.go
@@ -216,6 +216,9 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) error {
 				if err != nil {
 					return err
 				}
+				if group.Status.Descriptor == nil {
+					return errors.New("group descriptor is nil")
+				}
 				groupResource, err := groups.Get(ctx, e.azCli, groups.GetOptions{
 					Organization:    project.Spec.Organization,
 					GroupDescriptor: helpers.String(group.Status.Descriptor),
@@ -225,6 +228,9 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) error {
 				}
 				approverId = groupResource.OriginID
 			} else {
+				if user.Status.Descriptor == nil {
+					return errors.New("user descriptor is nil")
+				}
 				userResource, err := users.Get(ctx, e.azCli, users.GetOptions{
 					Organization:   project.Spec.Organization,
 					UserDescriptor: helpers.String(user.Status.Descriptor),


### PR DESCRIPTION
**Describe the bug** #53 

> Applying certain Deployment, it creates appropriate Environments and Groups resource on Azure DevOps, but the CheckConfigurations resource is not created.
> The error message associated with the CheckConfiguration resource is the following:
> "cannot determine creation result - remove the krateo.io/external-create-pending annotation if it is safe to proceed".

**Solution**
Composition creates Groups and Environments resources, but the creation of CheckConfiguration causes the controller to panic when the referenced Environment and Group creation is not completed. 

To fix the issue, the controller now reports an error but is then reconciled.
