### PR TITLE
CR checkconfiguration never in ready state - #55

### DIFF
--- a/samples/checkconfiguration.yaml
+++ b/samples/checkconfiguration.yaml
@@ -3,7 +3,7 @@ kind: CheckConfiguration
 metadata:
   name: check-sample-1
   annotations:
-    krateo.io/connector-verbose: "false"
+    krateo.io/connector-verbose: "true"
 spec:
   deletionPolicy: Delete
   projectRef: 
@@ -21,7 +21,10 @@ spec:
     approvers:
     - approverRef:
         namespace: default
-        name: group-compose
+        name: user-build
+    - approverRef:
+        namespace: default
+        name: group-test
   connectorConfigRef:
     namespace: default
     name: connectorconfig-sample


### PR DESCRIPTION
**Describe the bug**
when a new CheckConfiguration CR is created, even if is correctly managed by the provider, never goes in READY state

**Fix Description**
Ready state was never setted on the resource