### PR TITLE
Broken Update of ADO users

### DIFF
--- a/internal/controllers/users/users.go
+++ b/internal/controllers/users/users.go
@@ -215,12 +215,6 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) error {
 	if err != nil {
 		return err
 	}
-	user, err = users.Create[users.PrincipalName](ctx, e.azCli, users.CreateOptions[users.PrincipalName]{
-		Organization: cr.Spec.Organization,
-		Identifier: users.PrincipalName{
-			PrincipalName: user.PrincipalName,
-		},
-	})
 
 	for _, descriptor := range groupAndTeamDescriptors {
 		err = memberships.Create(ctx, e.azCli, memberships.CheckMembershipOptions{


### PR DESCRIPTION
> **Describe the bug**
> When a new User CR is created and the annotation "krateo.io/management-policy: observe-update" is setup, even if the spec.groupRefs array is filled, the ADO User is not updated and not inserted into the ADO groups placed in the array.
> If the annotation "krateo.io/management-policy: observe-update" is removed, a brand new user is always created on ADO (even if there is an existing ADO user with the exactly same name).

**Fix description**
This Pull Request (PR) addresses the issue with updating ADO groups #56. It's important to note that the annotation "krateo.io/management-policy: observe-update" is not part of the valid values for the provider-runtime.
