### PR TITLE
fix: fixed pagination when listing groups

### DIFF
--- a/internal/clients/azuredevops/graphs/groups/groups.go
+++ b/internal/clients/azuredevops/graphs/groups/groups.go
@@ -2,6 +2,7 @@ package groups
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"path"
 	"reflect"
@@ -163,18 +164,7 @@ func FindGroupByName(ctx context.Context, cli *azuredevops.Client, opts FindGrou
 		}
 		opts.ListOptions.ContinuationToken = groups.ContinuationToken
 	}
-
-	groups, err := List(ctx, cli, opts.ListOptions)
-	if err != nil {
-		return nil, err
-	}
-	for _, group := range groups.Value {
-		domain := path.Base(group.Domain)
-		if strings.EqualFold(group.DisplayName, opts.GroupName) && strings.EqualFold(domain, opts.ProjectID) {
-			return &group, nil
-		}
-	}
-	return nil, nil
+	return nil, fmt.Errorf("group not found with name: %s", opts.GroupName)
 }
 
 // Create a new Azure DevOps group.


### PR DESCRIPTION
**Describe the bug**
During the reconciliation, the provider search for an already created group with the same name described in the CR Groups. The search is performed at the organization level.
If the organization has more then 500 groups, the Azure Devops API makes pagination, but the provider doesn't apply pagination for reading all the results.
This makes the provider try to create new group at every reconciliation cycle because it never finds any group with the same name on Azure Devops Organization


**Solution**
Pagination was not correctly handled for Group resource.