### PR TITLE
fix: Correct calculation of endpoint share.

### DIFF
--- a/internal/clients/azuredevops/endpoints/utils.go
+++ b/internal/clients/azuredevops/endpoints/utils.go
@@ -1,6 +1,7 @@
 package endpoints
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -30,19 +31,17 @@ func Equal(a *ServiceEndpoint, b *ServiceEndpoint) bool {
 	if !reflect.DeepEqual(a.Data, b.Data) {
 		return false
 	}
-
+	found := 0
 	for _, ref := range a.ServiceEndpointProjectReferences {
-		found := false
 		for _, refb := range b.ServiceEndpointProjectReferences {
 			if reflect.DeepEqual(ref, refb) {
-				found = true
-				break
+				found++
 			}
-		}
-		if !found {
-			return false
 		}
 	}
 
-	return true
+	fmt.Println("found:", found)
+	fmt.Println("len:", len(a.ServiceEndpointProjectReferences))
+
+	return found == len(a.ServiceEndpointProjectReferences)
 }

--- a/internal/controllers/endpoints/endpoints.go
+++ b/internal/controllers/endpoints/endpoints.go
@@ -2,6 +2,7 @@ package endpoints
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"k8s.io/client-go/tools/record"
@@ -128,15 +129,15 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (reconciler
 		return reconciler.ExternalObservation{}, err
 	}
 
-	// // print the endpoint in json with indent
-	// fmt.Println("endpoint:")
-	// b, _ := json.MarshalIndent(endpoint, "", "  ")
-	// fmt.Println(string(b))
+	// print the endpoint in json with indent
+	fmt.Println("endpoint:")
+	b, _ := json.MarshalIndent(endpoint, "", "  ")
+	fmt.Println(string(b))
 
-	// // print the observed endpoint in json with indent
-	// fmt.Println("observed endpoint:")
-	// b, _ = json.MarshalIndent(observed, "", "  ")
-	// fmt.Println(string(b))
+	// print the observed endpoint in json with indent
+	fmt.Println("observed endpoint:")
+	b, _ = json.MarshalIndent(observed, "", "  ")
+	fmt.Println(string(b))
 
 	cr.Status.Id = observed.Id
 	cr.Status.Url = observed.Url
@@ -146,7 +147,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (reconciler
 		return reconciler.ExternalObservation{}, err
 	}
 
-	if !endpoints.Equal(observed, endpoint) {
+	if !endpoints.Equal(endpoint, observed) {
 		return reconciler.ExternalObservation{
 			ResourceExists:   true,
 			ResourceUpToDate: false,

--- a/samples/endpoint.yaml
+++ b/samples/endpoint.yaml
@@ -3,39 +3,40 @@ kind: Endpoint
 metadata:
   name: endpoint-sample
   annotations:
-    krateo.io/connector-verbose: "false"
+    krateo.io/connector-verbose: "true"
 spec:
-  name: endpoint-sample
+  deletionPolicy: Orphan
+  name: endpoint-sample-test-3
+  type: azurerm
   projectRef: 
     name: pipeline-proj
-    namespace: yournamespace
+    namespace: default
   authorization:
     parameters:
-      tenantid: 91b02abd-daec-432a-8ee4-b5137910aca6
+      tenantid: 1272a66f-e2e8-4e88-ab43-487409186c3f
+      serviceprincipalId: 1272a66f-e2e8-4e88-ab43-487409186c3f
       authenticationType: spnKey
-      scope: /subscriptions/97624910-2b37-4b00-8b9b-5155fd1daeda/resourcegroups/centrico
+      serviceprincipalKey: somePassword
     scheme: ServicePrincipal
   data:
     environment: AzureCloud
     scopeLevel: Subscription
-    subscriptionId: 0fe98abc-6028-4c53-9e43-200b66fac644
+    subscriptionId: 1272a66f-e2e8-4e88-ab43-487409186c3f
     subscriptionName: Microsoft Azure Sponsorship
-    creationMode: Automatic
-  isShared: true
-  owner: library
-  type: azurerm
+    creationMode: Manual
+  isShared: false
   url: https://management.azure.com/
   serviceEndpointProjectReferences:
     - description: description of the share
-      name: prova2
+      name: prova8
       projectRef: 
-        name: teamproject
-        namespace: yournamespace
+        name: test-shares
+        namespace: default
     - description: description of the share
-      name: prova1
+      name: prova9
       projectRef: 
-        name: anotherproject
-        namespace: yournamespace
+        name: test-share-1
+        namespace: default
   connectorConfigRef:
-    namespace: yournamespace
+    namespace: default
     name: connectorconfig-sample


### PR DESCRIPTION
**Describe the bug**
When an Endpoint CR is created with 'isShared' flag set to True and the 'serviceEndpointProjectReferences' array populated, the provider doesn't share the CR across projects.
Based on the logs, it first makes a GET call to

GET /{{organization}}/{{project}}s/_apis/serviceendpoint/endpoints?api-version=7.0&endpointNames={{endpoint.name}}includeFailed=false HTTP/1.1

If the GET request returns a valid response, the provider stop the reconciliation with success, without checking if the result is already shared across the desired projects placed in serviceEndpointProjectReferences array. (#62)

**Solution**
The bug was addressed by implementing a fix that corrects the algorithm responsible for calculating and applying the shared status of endpoints. This fix ensures that the provider checks if the endpoint is shared across the desired projects before concluding the reconciliation process.