### PR TITLE
fix: Correct the bug that prevent the controller to authorize pipelines

### DIFF
--- a/internal/clients/azuredevops/pipelinespermissions/pipelinepermissions.go
+++ b/internal/clients/azuredevops/pipelinespermissions/pipelinepermissions.go
@@ -2,6 +2,7 @@ package pipelinespermissions
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"path"
 	"reflect"
@@ -24,7 +25,7 @@ type PipelinePermission struct {
 }
 
 func (p *PipelinePermission) GetId() string {
-	return p.Id.(string)
+	return fmt.Sprintf("%v", p.Id)
 }
 
 type ResourcePipelinePermissions struct {

--- a/internal/controllers/pipelinepermissions/support.go
+++ b/internal/controllers/pipelinepermissions/support.go
@@ -1,0 +1,32 @@
+package pipelinepermissions
+
+import (
+	"context"
+	"fmt"
+
+	pipelineperm "github.com/krateoplatformops/azuredevops-provider/apis/pipelinepermissions/v1alpha2"
+	pipelinespermissions "github.com/krateoplatformops/azuredevops-provider/internal/clients/azuredevops/pipelinespermissions"
+	"github.com/krateoplatformops/azuredevops-provider/internal/resolvers"
+	"github.com/krateoplatformops/provider-runtime/pkg/helpers"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func checkPipelinePermission(ctx context.Context, kube client.Client, currentPip []pipelineperm.PipelineAuthorization, observedPip []pipelinespermissions.PipelinePermission) (bool, error) {
+	for _, current := range currentPip {
+		currentPip, err := resolvers.ResolvePipeline(ctx, kube, current.PipelineRef)
+		if err != nil {
+			return false, fmt.Errorf("cannot resolve pipeline: %w", err)
+		}
+		found := false
+		for _, observed := range observedPip {
+			if current.Authorized && helpers.String(currentPip.Status.Id) == observed.GetId() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false, nil
+		}
+	}
+	return true, nil
+}


### PR DESCRIPTION
**Describe the bug**
If PipelinePermission CR is created with spec.authorizeAll flag set tu false, no API call is triggered to AzureDevops in order to create the permission (no call to PATCH [https://dev.azure.com/{{organization}}/{{project}}/_apis/pipelines/pipelinepermissions/environment/{{environment}}](https://dev.azure.com/%7B%7Borganization%7D%7D/%7B%7Bproject%7D%7D/_apis/pipelines/pipelinepermissions/environment/%7B%7Benvironment%7D%7D)) #60 
 
**Solution**
The bug was addressed by implementing an algorithm that compares the authorizations specified in the PipelinePermission CR with the authorizations in the remote resource. The algorithm compares the authorizations specified in the CR with the current authorizations fetched from Azure DevOps and triggers a FETCH in case of discrepancies.