### PR TITLE
Groups controller does not create (#78)

### DIFF
--- a/internal/clients/azuredevops/graphs/groups/groups.go
+++ b/internal/clients/azuredevops/graphs/groups/groups.go
@@ -2,7 +2,6 @@ package groups
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"path"
 	"reflect"
@@ -164,7 +163,7 @@ func FindGroupByName(ctx context.Context, cli *azuredevops.Client, opts FindGrou
 		}
 		opts.ListOptions.ContinuationToken = groups.ContinuationToken
 	}
-	return nil, fmt.Errorf("group not found with name: %s", opts.GroupName)
+	return nil, nil
 }
 
 // Create a new Azure DevOps group.


### PR DESCRIPTION
**Describe the bug**
Using last revision of azure devops provider ( 0.17.5 ) Groups CR doesn't work as expected. Using the following manifest, the azure devops provider fails to create and observe the requested resource with the following error
`message: 'observe failed: group not found with name: Approvers' `


**Solution**
Removed unnecessary error (not really an error) that prevent creation of groups (#78)