### PR TITLE
Groups CRD controller makes unnecessary POST call

### DIFF
--- a/internal/clients/azuredevops/graphs/groups/groups.go
+++ b/internal/clients/azuredevops/graphs/groups/groups.go
@@ -143,7 +143,7 @@ func List(ctx context.Context, cli *azuredevops.Client, opts ListOptions) (*Grou
 type FindGroupByNameOptions struct {
 	ListOptions
 	GroupName string
-	ProjectID string
+	ProjectID *string
 }
 
 func FindGroupByName(ctx context.Context, cli *azuredevops.Client, opts FindGroupByNameOptions) (*GroupResponse, error) {
@@ -156,7 +156,9 @@ func FindGroupByName(ctx context.Context, cli *azuredevops.Client, opts FindGrou
 		}
 		for _, group := range groups.Value {
 			domain := path.Base(group.Domain)
-			if strings.EqualFold(group.DisplayName, opts.GroupName) && strings.EqualFold(domain, opts.ProjectID) {
+			if strings.EqualFold(group.DisplayName, opts.GroupName) &&
+				opts.ProjectID == nil || //if projectID is not provided, return the first group with the name - organization is from the api endpoint
+				strings.EqualFold(domain, helpers.String(opts.ProjectID)) {
 				return &group, nil
 			}
 		}

--- a/internal/controllers/groups/groups.go
+++ b/internal/controllers/groups/groups.go
@@ -125,7 +125,7 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (reconciler
 				Organization: helpers.String(organization),
 			},
 			GroupName: helpers.String(cr.Spec.GroupsName),
-			ProjectID: helpers.String(projectId),
+			ProjectID: projectId,
 		})
 		if err != nil {
 			return reconciler.ExternalObservation{}, err
@@ -221,7 +221,7 @@ func (e *external) Update(ctx context.Context, mg resource.Managed) error {
 			ListOptions: groups.ListOptions{
 				Organization: helpers.String(organization),
 			},
-			ProjectID: helpers.String(projectId),
+			ProjectID: projectId,
 			GroupName: helpers.String(cr.Spec.GroupsName),
 		})
 		if err != nil {


### PR DESCRIPTION
**Describe the bug**
The Groups Custom Resource Definition (CRD) controller makes an unnecessary POST call when the membership of a group is set at the organization level. The group is not retrieved, causing a trigger of the POST API. This behavior brings problems with low permission authentication tokens.

**Implemented Solution**
Fixed the bug that bring the controller to make unnecessary POST api call